### PR TITLE
Upgrade BouncyCastle

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -5,9 +5,10 @@ Scala wrappers for JCA/BouncyCastle classes
 Add to `build.sbt`:
 ```scala
 libraryDependencies ++= Seq(
-  "org.bouncycastle" % "bcprov-jdk15on" % "1.58",
-  "org.bouncycastle" % "bcpkix-jdk15on" % "1.58",
-  "com.github.karasiq" %% "cryptoutils" % "1.4.3"
+  "org.bouncycastle" % "bcprov-jdk15on" % "1.67",
+  "org.bouncycastle" % "bcpkix-jdk15on" % "1.67",
+  "org.bouncycastle" % "bctls-jdk15on" % "1.67",
+  "com.github.karasiq" %% "cryptoutils" % "2.0.0"
 )
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "cryptoutils"
 
 organization := "com.github.karasiq"
 
-version := "1.4.3"
+version := "2.0.0-SNAPSHOT"
 
 isSnapshot := version.value.endsWith("SNAPSHOT")
 
@@ -14,8 +14,9 @@ resolvers += "softprops-maven" at "http://dl.bintray.com/content/softprops/maven
 
 libraryDependencies ++= Seq(
   "commons-io" % "commons-io" % "2.5",
-  "org.bouncycastle" % "bcprov-jdk15on" % "1.58" % "provided",
-  "org.bouncycastle" % "bcpkix-jdk15on" % "1.58" % "provided",
+  "org.bouncycastle" % "bcprov-jdk15on" % "1.67" % "provided",
+  "org.bouncycastle" % "bcpkix-jdk15on" % "1.67" % "provided",
+  "org.bouncycastle" % "bctls-jdk15on" % "1.67" % "provided",
   "com.typesafe" % "config" % "1.3.1",
   "org.scalatest" %% "scalatest" % "3.0.4" % "test"
 )

--- a/src/main/scala/com/karasiq/tls/TLS.scala
+++ b/src/main/scala/com/karasiq/tls/TLS.scala
@@ -1,14 +1,14 @@
 package com.karasiq.tls
 
 object TLS {
-  type CertificateChain = org.bouncycastle.crypto.tls.Certificate
+  type CertificateChain = org.bouncycastle.tls.Certificate
   type Certificate = org.bouncycastle.asn1.x509.Certificate
   type CertificateKeyPair = org.bouncycastle.crypto.AsymmetricCipherKeyPair
 
   case class CertificateKey(certificateChain: CertificateChain, key: CertificateKeyPair) {
     def certificate: TLS.Certificate = {
       import com.karasiq.tls.internal.BCConversions._
-      certificateChain.toTlsCertificate
+      certificateChain.toCertificate
     }
   }
 

--- a/src/main/scala/com/karasiq/tls/TLSConnectionWrapper.scala
+++ b/src/main/scala/com/karasiq/tls/TLSConnectionWrapper.scala
@@ -2,7 +2,7 @@ package com.karasiq.tls
 
 import java.nio.channels.SocketChannel
 
-import org.bouncycastle.crypto.tls.{AlertDescription, TlsFatalAlert}
+import org.bouncycastle.tls.{AlertDescription, TlsFatalAlert}
 
 import scala.concurrent.Promise
 import scala.util.control.Exception

--- a/src/main/scala/com/karasiq/tls/TLSKeyStore.scala
+++ b/src/main/scala/com/karasiq/tls/TLSKeyStore.scala
@@ -113,7 +113,7 @@ class TLSKeyStore(val keyStore: KeyStore = TLSKeyStore.defaultKeyStore(), val pa
   }
 
   def getCertificate(alias: String): TLS.Certificate = {
-    keyStore.getCertificate(alias).toTlsCertificate
+    keyStore.getCertificate(alias).toCertificate
   }
 
   def getKeySet(alias: String, password: String = password): TLS.KeySet = {

--- a/src/main/scala/com/karasiq/tls/TLSServerWrapper.scala
+++ b/src/main/scala/com/karasiq/tls/TLSServerWrapper.scala
@@ -4,11 +4,13 @@ import java.nio.channels.SocketChannel
 import java.security.SecureRandom
 
 import com.karasiq.tls.TLS.CertificateChain
-import com.karasiq.tls.internal.BCConversions.CipherSuiteId
+import com.karasiq.tls.internal.BCConversions._
 import com.karasiq.tls.internal.{SocketChannelWrapper, TLSUtils}
 import com.karasiq.tls.x509.{CertificateVerifier, X509Utils}
 import org.bouncycastle.asn1.x509.KeyUsage
-import org.bouncycastle.crypto.tls._
+import org.bouncycastle.tls._
+import org.bouncycastle.tls.crypto.TlsCryptoParameters
+import org.bouncycastle.tls.crypto.impl.bc.{BcDefaultTlsCredentialedDecryptor, BcDefaultTlsCredentialedSigner, BcTlsCrypto}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -19,7 +21,7 @@ class TLSServerWrapper(keySet: TLS.KeySet, clientAuth: Boolean = false, verifier
 
   @throws(classOf[TlsFatalAlert])
   protected def onClientAuth(clientCertificate: CertificateChain): Unit = {
-    val chain: List[TLS.Certificate] = clientCertificate.getCertificateList.toList
+    val chain: List[TLS.Certificate] = clientCertificate.getCertificateList.toList.map(_.toCertificate)
     if (chain.nonEmpty) {
       onInfo(s"Client certificate chain: ${chain.map(_.getSubject).mkString("; ")}")
     }
@@ -33,14 +35,11 @@ class TLSServerWrapper(keySet: TLS.KeySet, clientAuth: Boolean = false, verifier
   }
 
   def apply(connection: SocketChannel): SocketChannel = {
-    val protocol = new TlsServerProtocol(SocketChannelWrapper.inputStream(connection), SocketChannelWrapper.outputStream(connection), SecureRandom.getInstanceStrong)
-    val server = new DefaultTlsServer() {
-      override def getMinimumVersion: ProtocolVersion = {
-        TLSUtils.minVersion()
-      }
-
-      override def getMaximumVersion: ProtocolVersion = {
-        TLSUtils.maxVersion()
+    val protocol = new TlsServerProtocol(SocketChannelWrapper.inputStream(connection), SocketChannelWrapper.outputStream(connection))
+    val crypto = new BcTlsCrypto(SecureRandom.getInstanceStrong)
+    val server = new DefaultTlsServer(crypto) {
+      override def getSupportedVersions: Array[ProtocolVersion] = {
+        TLSUtils.maxVersion().downTo(TLSUtils.minVersion())
       }
 
       override def getCipherSuites: Array[Int] = {
@@ -52,33 +51,33 @@ class TLSServerWrapper(keySet: TLS.KeySet, clientAuth: Boolean = false, verifier
         onInfo(s"Selected cipher suite: ${CipherSuiteId.asString(selectedCipherSuite)}")
       }
 
-      private def signerCredentials(certOption: Option[TLS.CertificateKey]): TlsSignerCredentials = {
+      private def signerCredentials(certOption: Option[TLS.CertificateKey]): TlsCredentialedSigner = {
         certOption.filter(c ⇒ X509Utils.isKeyUsageAllowed(c.certificate, KeyUsage.digitalSignature)).fold(throw new TLSException("No suitable signer credentials found")) { cert ⇒
-          new DefaultTlsSignerCredentials(context, cert.certificateChain, cert.key.getPrivate, TLSUtils.signatureAlgorithm(cert.key.getPrivate))
+          new BcDefaultTlsCredentialedSigner(new TlsCryptoParameters(context), crypto, cert.key.getPrivate, cert.certificateChain, TLSUtils.signatureAlgorithm(cert.key.getPrivate))
         }
       }
 
-      override def getRSASignerCredentials: TlsSignerCredentials = wrapException("Could not provide server RSA credentials") {
+      override def getRSASignerCredentials: TlsCredentialedSigner = wrapException("Could not provide server RSA credentials") {
         signerCredentials(keySet.rsa)
       }
 
-      override def getECDSASignerCredentials: TlsSignerCredentials = wrapException("Could not provide server ECDSA credentials") {
+      override def getECDSASignerCredentials: TlsCredentialedSigner = wrapException("Could not provide server ECDSA credentials") {
         signerCredentials(keySet.ecdsa)
       }
 
-      override def getDSASignerCredentials: TlsSignerCredentials = wrapException("Could not provide server DSA credentials") {
+      override def getDSASignerCredentials: TlsCredentialedSigner = wrapException("Could not provide server DSA credentials") {
         signerCredentials(keySet.dsa)
       }
 
-      override def getRSAEncryptionCredentials: TlsEncryptionCredentials = wrapException("Could not provide server RSA encryption credentials") {
+      override def getRSAEncryptionCredentials: TlsCredentialedDecryptor = wrapException("Could not provide server RSA encryption credentials") {
         keySet.rsa.filter(c ⇒ X509Utils.isKeyUsageAllowed(c.certificate, KeyUsage.keyEncipherment)).fold(super.getRSAEncryptionCredentials) { cert ⇒
-          new DefaultTlsEncryptionCredentials(context, cert.certificateChain, cert.key.getPrivate)
+          new BcDefaultTlsCredentialedDecryptor(crypto, cert.certificateChain, cert.key.getPrivate)
         }
       }
 
       override def getCertificateRequest: CertificateRequest = {
         if (clientAuth) {
-          TLSUtils.certificateRequest(this.getServerVersion, verifier)
+          TLSUtils.certificateRequest(this.getServerVersion, verifier, context)
         } else {
           null
         }

--- a/src/main/scala/com/karasiq/tls/internal/SocketChannelWrapper.scala
+++ b/src/main/scala/com/karasiq/tls/internal/SocketChannelWrapper.scala
@@ -6,7 +6,7 @@ import java.nio.ByteBuffer
 import java.nio.channels.SocketChannel
 import java.util
 
-import org.bouncycastle.crypto.tls.TlsProtocol
+import org.bouncycastle.tls.TlsProtocol
 import sun.nio.ch.{SelChImpl, SelectionKeyImpl}
 
 private[tls] object SocketChannelWrapper {

--- a/src/main/scala/com/karasiq/tls/internal/SocketWrapper.scala
+++ b/src/main/scala/com/karasiq/tls/internal/SocketWrapper.scala
@@ -4,7 +4,7 @@ import java.io.{InputStream, OutputStream}
 import java.net.{InetAddress, Socket, SocketAddress}
 import java.nio.channels.SocketChannel
 
-import org.bouncycastle.crypto.tls.TlsProtocol
+import org.bouncycastle.tls.TlsProtocol
 
 final private[tls] class SocketWrapper(connection: Socket, protocol: TlsProtocol) extends Socket {
   override def shutdownInput(): Unit = connection.shutdownInput()

--- a/src/main/scala/com/karasiq/tls/x509/CertificateGenerator.scala
+++ b/src/main/scala/com/karasiq/tls/x509/CertificateGenerator.scala
@@ -23,7 +23,7 @@ class CertificateGenerator {
   protected val secureRandom: SecureRandom = SecureRandom.getInstanceStrong
 
   private def makeChain(issuer: TLS.CertificateChain, certificate: TLS.Certificate): TLS.CertificateChain = {
-    new TLS.CertificateChain(Array(certificate) ++ issuer.getCertificateList)
+    new TLS.CertificateChain(Array(certificate.toTlsCertificate) ++ issuer.getCertificateList)
   }
 
   /**
@@ -55,7 +55,7 @@ class CertificateGenerator {
 
     val certificateBuilder = new X509v3CertificateBuilder(issuer.certificate.getSubject, serial.underlying(), new Date(), Date.from(notAfter),
       request.getSubject, request.getSubjectPublicKeyInfo)
-    
+
     (extensions ++ CertExtension.identifiers(request.getSubjectPublicKeyInfo, Some(issuer.certificate)) ++ CSRUtils.extensionsOf(request)).foreach { ext ⇒
       certificateBuilder.addExtension(ext.id, ext.critical, ext.value)
     }

--- a/src/main/scala/com/karasiq/tls/x509/ocsp/OCSP.scala
+++ b/src/main/scala/com/karasiq/tls/x509/ocsp/OCSP.scala
@@ -93,7 +93,9 @@ object OCSP {
     extGen.addExtension(OCSPObjectIdentifiers.id_pkix_ocsp_nonce, false, nonce)
     builder.setRequestExtensions(extGen.generate())
 
-    builder.build(X509Utils.contentSigner(signer.key.getPrivate.toPrivateKey), signer.certificateChain.getCertificateList.map(new X509CertificateHolder(_)))
+    builder.build(
+      X509Utils.contentSigner(signer.key.getPrivate.toPrivateKey),
+      signer.certificateChain.getCertificateList.map(tlsCert => new X509CertificateHolder(tlsCert.toCertificate)))
   }
 
   /**
@@ -117,7 +119,10 @@ object OCSP {
       case (b, Status(id, status)) ⇒
         b.addResponse(id, status)
     }
-    builder.build(X509Utils.contentSigner(signer.key.getPrivate.toPrivateKey), signer.certificateChain.getCertificateList.map(new X509CertificateHolder(_)), new Date())
+    builder.build(
+      X509Utils.contentSigner(signer.key.getPrivate.toPrivateKey),
+      signer.certificateChain.getCertificateList.map(tlsCert => new X509CertificateHolder(tlsCert.toCertificate)),
+      new Date())
   }
 
   private def loadUrl(url: String, request: OCSPReq): OCSPResp = concurrent.blocking {

--- a/src/test/scala/X509Test.scala
+++ b/src/test/scala/X509Test.scala
@@ -51,10 +51,10 @@ class X509Test extends FreeSpec with Matchers {
         PEM.certificationRequest.fromString(encoded).getSubject shouldBe request.getSubject
         val cert = keyGenerator.signRequest(request, certificationAuthority)
         val verifier = CertificateVerifier(CertificateStatusProvider.AlwaysValid, certificationAuthority.certificate)
-        assert(verifier.isChainValid(cert.getCertificateList.toList))
-        X509Utils.verifyAuthorityIdentifier(cert.toTlsCertificate, certificationAuthority.certificate) shouldBe Some(true)
-        X509Utils.verifyPublicKeyIdentifier(cert.toTlsCertificate, serverKeySet.ecdsa.get.key.getPublic.toSubjectPublicKeyInfo) shouldBe Some(true)
-        println("CSR signed: " + cert.toTlsCertificate.getSubject)
+        assert(verifier.isChainValid(cert.getCertificateList.toList.map(_.toCertificate)))
+        X509Utils.verifyAuthorityIdentifier(cert.toCertificate, certificationAuthority.certificate) shouldBe Some(true)
+        X509Utils.verifyPublicKeyIdentifier(cert.toCertificate, serverKeySet.ecdsa.get.key.getPublic.toSubjectPublicKeyInfo) shouldBe Some(true)
+        println("CSR signed: " + cert.toCertificate.getSubject)
       }
 
       "should read CRL" in {


### PR DESCRIPTION
This upgrades the library to use BouncyCastle 1.6.x and the new TLS API (the old one was deprecated and is now gone).

It might be worthwhile changing some of the type aliases in `com.karasiq.tls.TLS`. It's a bit annoying converting between the 4 different certificate types. I'm not even sure that it works correctly.